### PR TITLE
fix description/sequence_ontology line

### DIFF
--- a/source/allele/resource/gene/index.md.erb
+++ b/source/allele/resource/gene/index.md.erb
@@ -1,8 +1,9 @@
 ---
 title: Gene
 layout: resource
-alias: A genomic region related to a collection of transcript ReferenceSequences, given a name by one or more naming agencies.
-description: sequence_ontology: SO:0000704
+alias: 
+description: A genomic region related to a collection of transcript ReferenceSequences, given a name by one or more naming agencies.
+sequence_ontology: SO:0000704
 related_page: /allele/conceptual/gene
 schema: "/main/resources/clingen-xsd/gene.xsd"
 


### PR DESCRIPTION
It looks like two lines got joined incorrectly, and middleman complains of a YAML parsing exception.
