### PR TITLE
change styling of context to match what @larrybabb had done with other pages

### DIFF
--- a/source/allele/resource/canonical_allele/index.md.erb
+++ b/source/allele/resource/canonical_allele/index.md.erb
@@ -9,59 +9,59 @@ related_page_url: /allele/conceptual/canonical_allele
 schema: "/main/resources/clingen-xsd/canonicalallele.xsd"
 
 context:
-  - property: CanonicalAllele.id
+  - property: id
     control: 1..1
     type: Id
     definition: The logical identifier assigned by the source storage system.
     requirements: 
           
-  - property: CanonicalAllele.version
+  - property: version
     control: 0..1
     type: string
     definition: The publicly stable version of the CanonicalAllele instance represented by the source system. 
     requirements: |
       Version changes may occur due to changes in the set of relatedSimpleAllele's. 
           
-  - property: CanonicalAllele.meta
+  - property: meta
     control: 0..1
     type: Meta
     definition: The metadata about a resource. This is content in the resource that is maintained by the infrastructure. Changes to the content may not always be associated with version changes to the resource. 
     requirements: |
       Version changes may occur due to changes in the set of relatedSimpleAllele's. 
       
-  - property: CanonicalAllele.identifier
+  - property: identifier
     control: 0..*
     type: Identifier
     definition: Business identifier(s) assigned by external authorities that represents the equivalent CanonicalAllele instance represented by the source system.
     requirements: 
 
-  - property: CanonicalAllele.relatedIdentifier
+  - property: relatedIdentifier
     control: 0..*
     type: Identifier
     definition: Business identifier(s) assigned by external authorities that are not exactly representative of the CanonicalAllele instance, but provide a noteworthy alternative representation.
     requirements: 
     
-  - property: CanonicalAllele.active
+  - property: active
     control: 0..1
     type: boolean
     definition: Is the CanonicalAllele active, or is it invalid or superceded by a different CanonicalAllele.
     requirements: |
       The `replacement` property MUST contain one or more items if this is *true*, otherwise `replacement` MUST be empty.
 
-  - property: CanonicalAllele.replacement
+  - property: replacement
     control: 0..*
     type: Replacement
     definition: The CanonicalAllele to use instead in case it is found to describe the same allele as another CanonicalAllele
     requirements: >
 
-  - property: CanonicalAllele.canonicalAlleleType
+  - property: canonicalAlleleType
     control: 1..1
     type: code
     binding: CanonicalAlleleType
     definition: TODO
     requirements: >
 
-  - property: CanonicalAllele.complexity
+  - property: complexity
     control: 1..1
     type: code
     binding: CanonicalAlleleComplexity
@@ -69,7 +69,7 @@ context:
     requirements: |
       If this allele is simple, then it can contain one or more SimpleAlleles in the relatedSimpleAllele property. This value is immutable.
 
-  - property: CanonicalAllele.nested
+  - property: nested
     control: 0..*
     type: CanonicalAllele
     definition: The set of CanonicalAlleles that compose this ComplexCanonicalAllele. The children CanonicalAlleles of a complex CanonicalAllele instance.
@@ -83,7 +83,7 @@ context:
       Notes: - the cardinality of this property is actually 0,2..* (i.e. anything but one)
              - currently, the idea of nesting complex CanonicalAlleles within other complex CanonicalAlleles is not supported. 
       
-  - property: CanonicalAllele.composite
+  - property: composite
     control: 0..*
     type: CanonicalAllele
     definition: The composite, parent or complex CanonicalAllele instance(s) that this Canonical Allele is part of. 
@@ -91,7 +91,7 @@ context:
       * If this CanonicalAllele participates in one or more complex CanonicalAlleles then the `complexity` must be simple.
       * It is not requirement to pass the association to the set of complex CanonicalAlleles unless it is useful to the receiving service.
 
-  - property: CanonicalAllele.replacement
+  - property: replacement
     control: 0..*
     type: 
     binding: CanonicalAllele.Replacement
@@ -99,43 +99,43 @@ context:
     requirements: |
       If one or more `replacement` references exist then this CanonicalAllele should be `active` equal to false or inactive.
       
-  - property: CanonicalAllele.replacement.replacementType
+  - property: replacement.replacementType
     control: 1..1
     type: code
     binding: CanonicalAlleleReplacementType
     definition: Code for the type of replacement that occurs when CanonicalAlleles are merged or split after being published.  
     requirements: 
       
-  - property: CanonicalAllele.replacement.split
+  - property: replacement.split
     control: 0..1
     type: boolean
     definition: A boolean indicating whether or not the `target` was replaced by more than one CanonicalAllele. 
     requirements: |
       It may be possible to conceptually split a pre-existing CanonicalAllele and replace it with more than one new CanonicalAllele, without actually creating all of the new replacements.  This indicator provides a definitive value to represent whether the `target` represented more than one CanonicalAllele to begin with. 
       
-  - property: CanonicalAllele.replacement.target
+  - property: replacement.target
     control: 1..1
     type: CanonicalAllele
     definition: A reference to either the CanonicalAllele that replaces or is replaced-by the primary CanonicalAllele with which it is associated. 
     requirements: 
       
-  - property: CanonicalAllele.relatedSimpleAllele
+  - property: relatedSimpleAllele
     control: 0..*
     type: 
     definition: The set of SimpleAllele's that are canonically equivalent.
     requirements: >
       If this set changes over time then the CanonicalAllele.version should be incremented to allow external references to maintain a stable representation of their original reference.
 
-  - property: CanonicalAllele.relatedSimpleAllele.simpleAllele
+  - property: relatedSimpleAllele.simpleAllele
     control: 1..1
     type: SimpleAllele
     definition: A reference to a SimpleAllele that is part of the set of CanonicalAllele.relatedSimpleAlleles.
     requirements: 
 
-  - property: CanonicalAllele.relatedSimpleAllele.preferred
+  - property: relatedSimpleAllele.preferred
     control: 0..1
     type: boolean
-    definition: An indicator as to whether this Canonical.relatedSimpleAllele is the preferred representation for the CanonicalAllele.
+    definition: An indicator as to whether this CanonicalAllele.relatedSimpleAllele is the preferred representation for the CanonicalAllele.
     requirements: |
       * The current design provides this indicator as a basic means to producing a simplified human-readable representation of the CanonicalAllele by allowing the source system to determine which related SimpleAllele is preferred over all the others.
       * One and only one of the relatedSimpleAlleles must be set as the prefered one.  If a new related SimpleAllele is added or an existing one updated as preferred it would automatically override the prior related SimpleAllele that was set as preferred.

--- a/source/layouts/resource.erb
+++ b/source/layouts/resource.erb
@@ -1,6 +1,6 @@
 <% wrap_layout :layout do %>
    <% if current_page.data.context %>
-   <h2>Context</h2>
+   <h2>Definitions &amp; Bindings</h2>
    <script type="text/javascript">
    function toggle_visibility(clazz) {
       var hidername = clazz + '-hider'
@@ -19,27 +19,31 @@
    toggle_visibility('context-requirement');
    </script>
    <button onclick="toggle_visibility('context-requirement');">Toggle requirements</button>
-   <table class="table">
-      <thead><tr>
-         <th>Property</th>
-         <th>Control</th>
-         <th>Type</th>
-         <th>Definition</th>
-      </tr></thead>
-      <% current_page.data.context.each do |attribute| %>
-      <tr>
-         <td><%= attribute.property %></td>
-         <td><%= attribute.control %></td>
-         <td><%= attribute.type %></td>
-         <td><%= attribute.definition %></td>
-      </tr>
+
+   <% current_page.data.context.each do |attribute| %>
+   <h4 class="h4-definition" id="<%= current_page.data.title %>-definition">
+      <%= "#{current_page.data.title}.#{attribute.property}" %>
+   </h4>
+
+   <dl class="dl-horizontal dl-definition">
+      <dt>Definition</dt>
+      <dd><%= attribute.definition %></dd>
+      <dt>Control</dt>
+      <dd><%= attribute.control %></dd>
+      <% if attribute.binding %>
+      <dt>Binding</dt>
+      <dd><%= attribute.binding %></dd>
+      <% end %>
+      <dt>Type</dt>
+      <dd><%= attribute.type %></dd>
       <% if attribute.requirements %>
-      <tr class="context-requirement"><td></td><td colspan="3" class="context-requirement">
-         <%= render_markdown attribute.requirements %>
-      </td></tr>
+      <dt class="context-requirement">Requirements</dt>
+      <dd class="context-requirement"><%= render_markdown attribute.requirements %></dd>
       <% end %>
-      <% end %>
-      </table>
+   </dl>
+
+   <% end %>
+
    <% end %>
    <%= yield %>
    <h2>Schema</h2>


### PR DESCRIPTION
Just to put this out there for discussion, this would produce output similar to what @larrybabb has done for the other resource models, but using the 'context' data in the yaml header.
