### PR TITLE
Correct and normalize syntax in JSON-LD schemas

### DIFF
--- a/source/main/resources/example-jsonld/CanonicalAllele.jsonld
+++ b/source/main/resources/example-jsonld/CanonicalAllele.jsonld
@@ -26,7 +26,7 @@
             "@type":"@id"
         },
         "display":"fhir:display",
-        
+
         "CanonicalAllele":"clingen:CanonicalAllele",
         "RelatedSimpleAllele":"clingen:RelatedSimpleAllele",
 

--- a/source/main/resources/example-jsonld/Gene.jsonld
+++ b/source/main/resources/example-jsonld/Gene.jsonld
@@ -1,8 +1,8 @@
 {
     "@context":
     {
-        "fhir":"http://hl7.org/fhir/resources/"
-        "clingen":"http://clingen.org/model/allele/"
+        "fhir":"http://hl7.org/fhir/resources/",
+        "clingen":"http://clingen.org/model/allele/",
 
         "name":"http://schema.org/name",
 
@@ -12,7 +12,7 @@
         {
             "@id":"fhir:identifier",
             "@container":"@set"
-        }
+        },
         "use":"fhir:use",
         "label":"fhir:label",
         "system":
@@ -20,7 +20,7 @@
             "@id":"fhir:system",
             "@type":"@id"
         },
-        "value":"fhir:value"
+        "value":"fhir:value",
 
         "Gene":"clingen:Gene",
         "symbol":"clingen:symbol",

--- a/source/main/resources/example-jsonld/ReferenceSequence.jsonld
+++ b/source/main/resources/example-jsonld/ReferenceSequence.jsonld
@@ -28,13 +28,13 @@
         {
             "@id":"fhir:coding",
             "@collection":"@set"
-        }
+        },
         "code":"fhir:code",
         "reference":
         {
             "@id":"fhir:reference",
             "@type":"@id"
-        }
+        },
 
 
         "ReferenceSequence":"clingen:ReferenceSequence",
@@ -54,13 +54,13 @@
         },
         "cdsStart":
         {
-            @id:"clingen:cdsStart",
-            @type:"xsd:integer"
+            "@id":"clingen:cdsStart",
+            "@type":"xsd:integer"
         },
         "cdsEnd":
         {
-            @id:"clingen:cdsEnd",
-            @type:"xsd:integer"
+            "@id":"clingen:cdsEnd",
+            "@type":"xsd:integer"
         }
     }
 }

--- a/source/main/resources/example-jsonld/SimpleAllele.jsonld
+++ b/source/main/resources/example-jsonld/SimpleAllele.jsonld
@@ -40,23 +40,23 @@
             "@id":"fhir:primary",
             "@type":"xsd:boolean"
         },
-        "valueSet": "fhir:valueSet",
-        
+        "valueSet":"fhir:valueSet",
+
         "SimpleAllele":"clingen:SimpleAllele",
-        "ReferenceCoordinate": "clingen:ReferenceCoordinate",
+        "ReferenceCoordinate":"clingen:ReferenceCoordinate",
         "IntronOffsetGenomicCoordinate":"clingen:IntronOffsetGenomicCoordinate",
         "AlleleName":"clingen:AlleleName",
-        "PrimaryNucleotideChangeType":"clingen:PrimaryNucleotideChangeType"
-        "PrimaryTranscriptRegionType":"clingen:PrimaryTranscriptRegionType"
+        "PrimaryNucleotideChangeType":"clingen:PrimaryNucleotideChangeType",
+        "PrimaryTranscriptRegionType":"clingen:PrimaryTranscriptRegionType",
 
         "allele":"clingen:allele",
-        "referenceCoordinate": "clingen:referencecoordinate",
+        "referenceCoordinate":"clingen:referencecoordinate",
         "refAllele":"clingen:refAllele",
         "intronOffsetGenomicCoordinate":"clingen:intronoffsetgenomiccoordinate",
         "canonicalAllele":"clingen:canonicalallele",
         "primaryNucleotideChangeType":"clingen:primarynucleotidechangetype",
         "primaryTranscriptRegionType":"clingen:primarytranscriptregiontype",
-        "referenceSequence": "clingen:referencesequence" ,
+        "referenceSequence":"clingen:referencesequence",
 
         "simpleAlleleType":
         {
@@ -76,13 +76,13 @@
         },
         "start":
         {
-            @id:"clingen:start",
-            @type:"xsd:integer"
+            "@id":"clingen:start",
+            "@type":"xsd:integer"
         },
         "end":
         {
-            @id:"clingen:end",
-            @type:"xsd:integer"
+            "@id":"clingen:end",
+            "@type":"xsd:integer"
         },
         "primaryTranscriptRegionType":
         {
@@ -118,13 +118,13 @@
         "alleleName":
         {
             "@id":"clingen:allelename",
-            "@container":"@set",
+            "@container":"@set"
         },
         "nametype":
         {
-            "@id":"clingen:allelenametype"
+            "@id":"clingen:allelenametype",
             "@type":"clingen:SimpleAlleleNameType"
-        }
+        },
         "legacy":
         {
             "@id":"clingen:legacy",


### PR DESCRIPTION
The JSON-LD files are not currently usable because they cannot be parsed. This patch both fixes the syntax errors and normalizes the coding style in the schema files.
