### PR TITLE
Correct and normalize syntax in examples

### DIFF
--- a/source/main/resources/example-json/CA401-NM_001014794.2-c.448+13A>G.json
+++ b/source/main/resources/example-json/CA401-NM_001014794.2-c.448+13A>G.json
@@ -4,28 +4,28 @@
   "active": "true",
   "canonicalAlleleType": "nucleotide",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA302",
-        "display": "NM_001014794.2(ILK):c.448+13A>G "
+        "display": "NM_001014794.2(ILK):c.448+13A>G"
       },
 
       "preferred": "true"
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA301",
-        "display": "NM_001014794.2(ILK):c.448+14A>G "
+        "display": "NM_001014794.2(ILK):c.448+14A>G"
       }
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA303",
         "display": "NC_000011.9:g.6630034A>G (GRCh37)"
@@ -33,7 +33,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA304",
         "display": "NC_000011.10:g.6608803A>G (GRCh38)"

--- a/source/main/resources/example-json/CA402-NM_007294.3-BRCA1-c.5297T>G.json
+++ b/source/main/resources/example-json/CA402-NM_007294.3-BRCA1-c.5297T>G.json
@@ -1,7 +1,7 @@
 {
   "id": "CA402",
   "version": "1",
-  "relatedIdentifier": 
+  "relatedIdentifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/clinvar/variation",
@@ -12,10 +12,10 @@
   "active": "true",
   "canonicalAlleleType": "nucleotide",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA310",
         "display": "NM_007294.3:c.5297T>G"
@@ -25,15 +25,15 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA311",
-        "display": "U14681.1(BRCA1):n.5416T>G "
+        "display": "U14681.1(BRCA1):n.5416T>G"
       }
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA313",
         "display": "NR_027676.1:n.5433T>G"
@@ -41,7 +41,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA314",
         "display": "NC_000017.10:g.41203115A>C (GRCh37)"
@@ -49,7 +49,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA315",
         "display": "NC_000017.11:g.43051098A>C (GRCh38)"
@@ -57,7 +57,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA316",
         "display": "NG_005905.2:g.166886T>G"
@@ -65,7 +65,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA317",
         "display": "LRG_292:g.166886T>G"
@@ -73,7 +73,7 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA318",
         "display": "LRG_292t1:c.5297T>G"

--- a/source/main/resources/example-json/CA403-NP_0099225.1-BRCA1-p.Ile1766Ser.json
+++ b/source/main/resources/example-json/CA403-NP_0099225.1-BRCA1-p.Ile1766Ser.json
@@ -1,7 +1,7 @@
 {
   "id": "CA403",
   "version": "1",
-  "relatedIdentifier": 
+  "relatedIdentifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/clinvar/variation",
@@ -12,10 +12,10 @@
   "active": "true",
   "canonicalAlleleType": "amino-acid",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA312",
         "display": "NP_009225.1(BRCA1):p.Ile1766Ser"
@@ -25,10 +25,10 @@
     },
 
     {
-      "simpleAllele": 
+      "simpleAllele":
       {
         "reference": "SimpleAllele/SA319",
-        "display": "LRG_292p1(BRCA1):p.Ile1766Ser "
+        "display": "LRG_292p1(BRCA1):p.Ile1766Ser"
       }
     }
   ]

--- a/source/main/resources/example-json/G101-ILK.json
+++ b/source/main/resources/example-json/G101-ILK.json
@@ -1,6 +1,6 @@
 {
   "id": "G101",
-  "identifier": 
+  "identifier":
   [
     {
       "use": "official",

--- a/source/main/resources/example-json/G102-BRCA1.json
+++ b/source/main/resources/example-json/G102-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "G102",
-  "identifier": 
+  "identifier":
   [
     {
       "use": "official",
@@ -16,7 +16,7 @@
 
   "symbol": "BRCA1",
   "name": "breast cancer 1, early onset",
-  "aliasSymbol": 
+  "aliasSymbol":
   [
     "IRIS",
     "PSCP",

--- a/source/main/resources/example-json/RS201-NM_001014794.2-ILK.json
+++ b/source/main/resources/example-json/RS201-NM_001014794.2-ILK.json
@@ -1,6 +1,6 @@
 {
   "id": "RS201",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -11,7 +11,7 @@
   "referenceSequenceType": "transcript",
   "cdsStart": "162",
   "cdsEnd": "1520",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G101"
   }

--- a/source/main/resources/example-json/RS202-NC_000011.9-b37.json
+++ b/source/main/resources/example-json/RS202-NC_000011.9-b37.json
@@ -1,6 +1,6 @@
 {
   "id": "RS202",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -10,9 +10,9 @@
 
   "referenceSequenceType": "chromsome",
   "chromosome": "11",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/assembly/",

--- a/source/main/resources/example-json/RS203-NC_000011.10-b38.json
+++ b/source/main/resources/example-json/RS203-NC_000011.10-b38.json
@@ -1,6 +1,6 @@
 {
   "id": "RS203",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -10,9 +10,9 @@
 
   "referenceSequenceType": "chromsome",
   "chromosome": "11",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/assembly/",

--- a/source/main/resources/example-json/RS210-NC_000017.11-b38.json
+++ b/source/main/resources/example-json/RS210-NC_000017.11-b38.json
@@ -1,6 +1,6 @@
 {
   "id": "RS210",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -10,9 +10,9 @@
 
   "referenceSequenceType": "chromsome",
   "chromosome": "17",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/assembly/",

--- a/source/main/resources/example-json/RS211-NC_000017.10-b37.json
+++ b/source/main/resources/example-json/RS211-NC_000017.10-b37.json
@@ -1,6 +1,6 @@
 {
   "id": "RS211",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -10,9 +10,9 @@
 
   "referenceSequenceType": "chromsome",
   "chromosome": "17",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/assembly/",

--- a/source/main/resources/example-json/RS212-NG_005905.2-BRCA1.json
+++ b/source/main/resources/example-json/RS212-NG_005905.2-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS212",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -9,7 +9,7 @@
   ],
 
   "referenceSequenceType": "gene",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G102"
   }

--- a/source/main/resources/example-json/RS213-NM_007294.3-BRCA1.json
+++ b/source/main/resources/example-json/RS213-NM_007294.3-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS213",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -11,15 +11,15 @@
   "referenceSequenceType": "transcript",
   "cdsStart": "233",
   "cdsEnd": "5824",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G102"
   },
 
-  "related": 
+  "related":
   {
     "relatedType": "translates-to",
-    "target": 
+    "target":
     {
       "reference": "ReferenceSequence/RS214",
       "display": "NP_009225.1 (BRCA1 Isoform 1)"

--- a/source/main/resources/example-json/RS214-NP_009225.1-BRCA1.json
+++ b/source/main/resources/example-json/RS214-NP_009225.1-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS214",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/protein",
@@ -9,10 +9,10 @@
   ],
 
   "referenceSequenceType": "amino-acid",
-  "related": 
+  "related":
   {
     "relatedType": "translates-from",
-    "target": 
+    "target":
     {
       "reference": "ReferenceSequence/RS213",
       "display": "NM_007294.3 (BRCA1 transcript variant 1)"

--- a/source/main/resources/example-json/RS215-U14680.1-BRCA1.json
+++ b/source/main/resources/example-json/RS215-U14680.1-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS215",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
@@ -11,7 +11,7 @@
   "referenceSequenceType": "transcript",
   "cdsStart": "120",
   "cdsEnd": "5711",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G102"
   }

--- a/source/main/resources/example-json/RS216-LRG_292p1-BRCA1.json
+++ b/source/main/resources/example-json/RS216-LRG_292p1-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS216",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://ftp.ebi.ac.uk/pub/databases/lrgex",
@@ -9,10 +9,10 @@
   ],
 
   "referenceSequenceType": "amino-acid",
-  "related": 
+  "related":
   {
     "relatedType": "translates-from",
-    "target": 
+    "target":
     {
       "reference": "ReferenceSequence/RS217",
       "display": "LRG_292t1"

--- a/source/main/resources/example-json/RS217-LRG_292t1-BRCA1.json
+++ b/source/main/resources/example-json/RS217-LRG_292t1-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS217",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://ftp.ebi.ac.uk/pub/databases/lrgex",
@@ -11,15 +11,15 @@
   "referenceSequenceType": "transcript",
   "cdsStart": "233",
   "cdsEnd": "5824",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G102"
   },
 
-  "related": 
+  "related":
   {
     "relatedType": "translates-to",
-    "target": 
+    "target":
     {
       "reference": "ReferenceSequence/RS216",
       "display": "LRG_292p1"

--- a/source/main/resources/example-json/RS218-LRG_292-BRCA1.json
+++ b/source/main/resources/example-json/RS218-LRG_292-BRCA1.json
@@ -1,6 +1,6 @@
 {
   "id": "RS218",
-  "identifier": 
+  "identifier":
   [
     {
       "system": "http://ftp.ebi.ac.uk/pub/databases/lrgex",
@@ -9,7 +9,7 @@
   ],
 
   "referenceSequenceType": "gene",
-  "gene": 
+  "gene":
   {
     "reference": "Gene/G102"
   }

--- a/source/main/resources/example-json/SA301-NM_001014794.2-ILK-c.448+14A>G-b37.json
+++ b/source/main/resources/example-json/SA301-NM_001014794.2-ILK-c.448+14A>G-b37.json
@@ -1,16 +1,16 @@
 {
   "id": "SA301",
 
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -21,7 +21,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-cdna",
@@ -30,9 +30,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS201",
       "display": "NM_001014794.2"
@@ -41,9 +41,9 @@
     "start": "608",
     "end": "608",
     "refAllele": "A",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",
@@ -57,9 +57,9 @@
   "intronOffsetStart": "13",
   "intronOffsetEnd": "14",
   "intronOffsetDirection": "+",
-  "intronOffsetGenomicCoordinate": 
+  "intronOffsetGenomicCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS202",
       "display": "NC_000011.9"

--- a/source/main/resources/example-json/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.json
+++ b/source/main/resources/example-json/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.json
@@ -1,16 +1,16 @@
 {
   "id": "SA302",
 
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -21,7 +21,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-cdna",
@@ -30,9 +30,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "/ReferenceSequence/RS201",
       "display": "NM_001014794.2"
@@ -41,9 +41,9 @@
     "start": "608",
     "end": "608",
     "refAllele": "A",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",
@@ -56,9 +56,9 @@
     "intronOffsetStart": "12",
     "intronOffsetEnd": "13",
     "intronOffsetDirection" : "+",
-    "intronOffsetGenomicCoordinate": 
+    "intronOffsetGenomicCoordinate":
     {
-      "referenceSequence": 
+      "referenceSequence":
       {
         "reference": "ReferenceSequence/RS203",
         "display": "NC_000011.10"

--- a/source/main/resources/example-json/SA303-NC_000011.9-g.6630034A>G-b37.json
+++ b/source/main/resources/example-json/SA303-NC_000011.9-g.6630034A>G-b37.json
@@ -1,15 +1,15 @@
 {
   "id": "SA303",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS202",
       "display": "NC_000011.9"

--- a/source/main/resources/example-json/SA304-NC_000011.10-g.6608803A>G-b38.json
+++ b/source/main/resources/example-json/SA304-NC_000011.10-g.6608803A>G-b38.json
@@ -1,15 +1,15 @@
 {
   "id": "SA304",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS203",
       "display": "NC_000011.10"

--- a/source/main/resources/example-json/SA310-NM_007294.3-BRCA1-c.5297T>G.json
+++ b/source/main/resources/example-json/SA310-NM_007294.3-BRCA1-c.5297T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA310",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-cdna",
@@ -34,9 +34,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -44,7 +44,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS213",
       "display": "NM_001014794.2"
@@ -53,9 +53,9 @@
     "start": "5296",
     "end": "5297",
     "refAllele": "T",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",
@@ -66,11 +66,11 @@
     }
   },
 
-  "related": 
+  "related":
   [
     {
       "relatedType": "amino-acid-effect",
-      "target": 
+      "target":
       {
         "reference": "SimpleAllele/SA312",
         "display": "NP_009225.1:p.Ile1766Ser"

--- a/source/main/resources/example-json/SA311-U14680.1-BRCA1-n.5416T>G.json
+++ b/source/main/resources/example-json/SA311-U14680.1-BRCA1-n.5416T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA311",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-rna",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -38,7 +38,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS215",
       "display": "U14680.1"
@@ -47,9 +47,9 @@
     "start": "5415",
     "end": "5416",
     "refAllele": "T",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",

--- a/source/main/resources/example-json/SA312-NP_009225.1-BRCA1-p.Ile1766Ser.json
+++ b/source/main/resources/example-json/SA312-NP_009225.1-BRCA1-p.Ile1766Ser.json
@@ -1,15 +1,15 @@
 {
   "id": "SA312",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA403"
   },
 
   "simpleAlleleType": "amino-acid",
   "allele": "Ser",
-  "primaryAminoAcidChangeType": 
+  "primaryAminoAcidChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -19,7 +19,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-protein-3",
@@ -32,9 +32,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -42,7 +42,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS214",
       "display": "NP_009225.1"
@@ -53,11 +53,11 @@
     "refAllele": "Ile"
   },
 
-  "related": 
+  "related":
   [
     {
       "relatedType": "transcript-allele-cause",
-      "target": 
+      "target":
       {
         "reference": "SimpleAllele/SA310",
         "display": "NM_007294.3(BRCA1):c.5297T>G"

--- a/source/main/resources/example-json/SA313-NR_027676.1-BRCA1-n.5433T>G.json
+++ b/source/main/resources/example-json/SA313-NR_027676.1-BRCA1-n.5433T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA313",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-ncrna",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -38,7 +38,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS213",
       "display": "NM_001014794.2"
@@ -47,9 +47,9 @@
     "start": "5432",
     "end": "5433",
     "refAllele": "T",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",

--- a/source/main/resources/example-json/SA314-NC_000017.10-g.41203115A>C-b37.json
+++ b/source/main/resources/example-json/SA314-NC_000017.10-g.41203115A>C-b37.json
@@ -1,15 +1,15 @@
 {
   "id": "SA314",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "C",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS211",
       "display": "NC_000017.10"

--- a/source/main/resources/example-json/SA315-NC_000017.11-g.43051098A>C-b38.json
+++ b/source/main/resources/example-json/SA315-NC_000017.11-g.43051098A>C-b38.json
@@ -1,15 +1,15 @@
 {
   "id": "SA315",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "C",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS210",
       "display": "NC_000017.11"

--- a/source/main/resources/example-json/SA316-NG_005905.2-BRCA1-g.166886T>G.json
+++ b/source/main/resources/example-json/SA316-NG_005905.2-BRCA1-g.166886T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA316",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS212",
       "display": "NG_005905.2"

--- a/source/main/resources/example-json/SA317-LRG_292-BRCA1-g.166886T>G.json
+++ b/source/main/resources/example-json/SA317-LRG_292-BRCA1-g.166886T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA317",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "genomic",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-genomic",
@@ -28,9 +28,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -38,7 +38,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS218",
       "display": "LRG_292"

--- a/source/main/resources/example-json/SA318-LRG_292t1-BRCA1-c.5297T>G.json
+++ b/source/main/resources/example-json/SA318-LRG_292t1-BRCA1-c.5297T>G.json
@@ -1,15 +1,15 @@
 {
   "id": "SA318",
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "CanonicalAllele/CA402"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -20,7 +20,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-cdna",
@@ -29,9 +29,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -39,7 +39,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "ReferenceSequence/RS217",
       "display": "LRG_292t1"
@@ -48,9 +48,9 @@
     "start": "5296",
     "end": "5297",
     "refAllele": "T",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "coding": 
+      "coding":
       [
         {
           "system": "http://www.sequenceontology.org/",

--- a/source/main/resources/example-json/SA319-LRG_292p1-BRCA1-p.Ile1766Ser.json
+++ b/source/main/resources/example-json/SA319-LRG_292p1-BRCA1-p.Ile1766Ser.json
@@ -1,6 +1,6 @@
 {
   "id": "SA319",
-  "identifier": 
+  "identifier":
   [
     {
       "label": "LRG_292p1:p.Ile1766Ser",
@@ -9,16 +9,16 @@
     }
   ],
 
-  "canonicalAllele": 
+  "canonicalAllele":
   {
     "reference": "/CanonicalAllele/CA403"
   },
 
   "simpleAlleleType": "amino-acid",
   "allele": "Ser",
-  "primaryAminoAcidChangeType": 
+  "primaryAminoAcidChangeType":
   {
-    "coding": 
+    "coding":
     [
       {
         "system": "http://www.sequenceontology.org/",
@@ -28,7 +28,7 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
       "nameType": "hgvs-protein-3",
@@ -41,9 +41,9 @@
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "identifier": 
+    "identifier":
     [
       {
         "system": "http://www.ncbi.nlm.nih.gov/snp",
@@ -51,7 +51,7 @@
       }
     ],
 
-    "referenceSequence": 
+    "referenceSequence":
     {
       "reference": "/ReferenceSequence/RS216",
       "display": "LRG_292p1"
@@ -62,11 +62,11 @@
     "refAllele": "Ile"
   },
 
-  "related": 
+  "related":
   [
     {
       "relatedType": "transcript-allele-cause",
-      "target": 
+      "target":
       {
         "reference": "/SimpleAllele/SA318",
         "display": "LRG_292t1(BRCA1):c.5297T>G"

--- a/source/main/resources/example-jsonld-nofhir/CA401-NM_001014794.2-c.448+13A>G.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/CA401-NM_001014794.2-c.448+13A>G.jsonld
@@ -1,37 +1,37 @@
 {
-  "@context":"http://clingen.org/models/CanonicalAllele.jsonld",
+  "@context": "http://clingen.org/models/CanonicalAllele.jsonld",
   "@id": "http://clingendb.clingen.org/CanonicalAllele/CA401",
-  "@type":"CanonicalAllele",
-  "xref": [
-  {
+  "@type": "CanonicalAllele",
+  "xref":
+  [
     "http://clingen.org/alleleregistry/CA401"
-  }],
+  ],
 
   "id" : "CA401",
   "version": "1",
   "active": "true",
   "canonicalAlleleType": "nucleotide",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA302",
       "display": "NM_001014794.2(ILK):c.448+13A>G",
       "preferred": "true"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA301",
       "display": "NM_001014794.2(ILK):c.448+14A>G"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA303",
       "display": "NC_000011.9:g.6630034A>G (GRCh37)"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA304",
       "display": "NC_000011.10:g.6608803A>G (GRCh38)"
     }

--- a/source/main/resources/example-jsonld-nofhir/CA402-NM_007294.3-BRCA1-c.5297T>G.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/CA402-NM_007294.3-BRCA1-c.5297T>G.jsonld
@@ -1,67 +1,65 @@
 {
-  "@context":"http://clingen.org/models/CanonicalAllele.jsonld",
+  "@context": "http://clingen.org/models/CanonicalAllele.jsonld",
   "@id": "http://clingendb.clingen.org/CanonicalAllele/CA402",
-  "@type":"CanonicalAllele",
-  "xref": 
+  "@type": "CanonicalAllele",
+  "xref":
   [
-    {
-      "http://www.ncbi.nlm.nih.gov/clinvar/variation/37656"
-    }
+    "http://www.ncbi.nlm.nih.gov/clinvar/variation/37656"
   ],
-  
+
   "id" : "CA402",
   "version": "1",
   "relatedIdentifier":
   [
     {
-      "@type":"RelatedIdentifier", 
-      "system":"http://www.ncbi.nlm.nih.gov/clinvar/variation",
+      "@type": "RelatedIdentifier",
+      "system": "http://www.ncbi.nlm.nih.gov/clinvar/variation",
       "value": "37656"
     }
   ],
   "active": "true",
   "canonicalAlleleType": "nucleotide",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "@type":"RelatedSimpleAllele", 
-      "simpleAllele":"../../SimpleAllele/SA310",
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele": "../../SimpleAllele/SA310",
       "display": "NM_007294.3:c.5297T>G",
       "preferred": "true"
     },
     {
-      "@type":"RelatedSimpleAllele", 
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA311",
-      "display": "U14681.1(BRCA1):n.5416T>G "
+      "display": "U14681.1(BRCA1):n.5416T>G"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA313",
       "display": "NR_027676.1:n.5433T>G"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA314",
       "display": "NC_000017.10:g.41203115A>C (GRCh37)"
     },
     {
-      "@type":"RelatedSimpleAllele", 
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA315",
       "display": "NC_000017.11:g.43051098A>C (GRCh38)"
     },
     {
-      "@type":"RelatedSimpleAllele", 
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA316",
       "display": "NG_005905.2:g.166886T>G"
     },
     {
-      "@type":"RelatedSimpleAllele", 
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA317",
       "display": "LRG_292:g.166886T>G"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA318",
       "display": "LRG_292t1:c.5297T>G"
     }

--- a/source/main/resources/example-jsonld-nofhir/CA403-NP_0099225.1-BRCA1-p.Ile1766Ser.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/CA403-NP_0099225.1-BRCA1-p.Ile1766Ser.jsonld
@@ -1,28 +1,26 @@
 {
-  "@context":"http://clingen.org/models/CanonicalAllele.jsonld",
+  "@context": "http://clingen.org/models/CanonicalAllele.jsonld",
   "@id": "http://clingendb.clingen.org/CanonicalAllele/CA403",
-  "xref": 
+  "xref":
   [
-    {
-      "http://clingen.org/alleleregistry/CA403"
-    }
+    "http://clingen.org/alleleregistry/CA403"
   ],
 
   "active": "true",
   "canonicalAlleleType": "amino acid",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "@type":"RelatedSimpleAllele",
-      "simpleAllele":"../..//SimpleAllele/SA312",
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele": "../..//SimpleAllele/SA312",
       "display": "NP_009225.1(BRCA1):p.Ile1766Ser",
       "preferred": "true"
     },
     {
-      "@type":"RelatedSimpleAllele",
+      "@type": "RelatedSimpleAllele",
       "simpleAllele": "../../SimpleAllele/SA319",
-      "display": "LRG_292p1(BRCA1):p.Ile1766Ser "
+      "display": "LRG_292p1(BRCA1):p.Ile1766Ser"
     }
   ]
 }

--- a/source/main/resources/example-jsonld-nofhir/G101-ILK.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/G101-ILK.jsonld
@@ -1,7 +1,7 @@
 {
-    "@context":"http://clingen.org/models/Gene.jsonld"
-    "@id":"http://clingendb.clingen.org/Gene/G101",
-    "@type":"Gene",
+    "@context": "http://clingen.org/models/Gene.jsonld",
+    "@id": "http://clingendb.clingen.org/Gene/G101",
+    "@type": "Gene",
     "id": "G101",
     "symbol": "ILK",
     "name": "integrin-linked kinase",

--- a/source/main/resources/example-jsonld-nofhir/G102-BRCA1.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/G102-BRCA1.jsonld
@@ -1,16 +1,16 @@
 {
-  "@context":"http://clingen.org/models/Gene.jsonld",
+  "@context": "http://clingen.org/models/Gene.jsonld",
   "@id": "http://clingendb.clingen.org/Gene/G102",
   "@type": "clingen:Gene",
   "id": "G102",
-  "xref": 
+  "xref":
   [
-     "http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:1100",
-     "http://www.ncbi.nlm.nih.gov/gene/672"
+    "http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:1100",
+    "http://www.ncbi.nlm.nih.gov/gene/672"
   ],
   "symbol": "BRCA1",
   "name": "breast cancer 1, early onset",
-  "aliasSymbol": 
+  "aliasSymbol":
   [
     "IRIS",
     "PSCP",

--- a/source/main/resources/example-jsonld-nofhir/RS201-NM_001014794.2-ILK.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/RS201-NM_001014794.2-ILK.jsonld
@@ -1,16 +1,14 @@
 {
-  "@context":"http://clingen.org/models/ReferenceSequence.jsonld",
+  "@context": "http://clingen.org/models/ReferenceSequence.jsonld",
   "@id": "http://clingendb.clingen.org/ReferenceSequence/RS201",
-  "@type": "ReferenceSequence"
-  "xref": 
+  "@type": "ReferenceSequence",
+  "xref":
   [
-      "http://www.ncbi.nlm.nih.gov/nuccore/NM_001014794.2"
+    "http://www.ncbi.nlm.nih.gov/nuccore/NM_001014794.2"
   ],
 
   "referenceSequenceType": "transcript",
   "cdsStart": "162",
   "cdsEnd": "1520",
   "gene": "../../Gene/G101"
-  }
-        
 }

--- a/source/main/resources/example-jsonld-nofhir/RS202-NC_000011.9-b37.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/RS202-NC_000011.9-b37.jsonld
@@ -1,18 +1,18 @@
 {
-  "@context":"http://clingen.org/models/ReferenceSequence.jsonld",
+  "@context": "http://clingen.org/models/ReferenceSequence.jsonld",
   "@id": "http://clingendb.clingen.org/ReferenceSequence/RS202",
-  "@type:":"ReferenceSequence",
-  "xref": 
-  [ 
-      "http://www.ncbi.nlm.nih.gov/nuccore/NC_000011.9"
+  "@type:": "ReferenceSequence",
+  "xref":
+  [
+    "http://www.ncbi.nlm.nih.gov/nuccore/NC_000011.9"
   ],
 
   "referenceSequenceType": "chromosome",
   "chromosome": "11",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "@type":"ReferenceGenome",
-    "@id":"http://www.ncbi.nlm.nih.gov/assembly/2758",
+    "@type": "ReferenceGenome",
+    "@id": "http://www.ncbi.nlm.nih.gov/assembly/2758",
     "name": "GRCh37"
   }
 }

--- a/source/main/resources/example-jsonld-nofhir/RS203-NC_000011.10-b38.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/RS203-NC_000011.10-b38.jsonld
@@ -1,17 +1,17 @@
 {
-  "@context":"http://clingen.org/models/ReferenceSequence.jsonld",
+  "@context": "http://clingen.org/models/ReferenceSequence.jsonld",
   "@id": "http://clingendb.clingen.org/ReferenceSequence/RS203",
-  "@type":"ReferenceSequence",
-  "xref": 
+  "@type": "ReferenceSequence",
+  "xref":
   [
     "http://www.ncbi.nlm.nih.gov/nuccore/NC_000011.10"
   ],
 
   "referenceSequenceType": "chromosome",
   "chromosome": "11",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "@type":"ReferenceGenome",
+    "@type": "ReferenceGenome",
     "@id": "http://www.ncbi.nlm.nih.gov/assembly/88331",
     "name": "GRCh38"
   }

--- a/source/main/resources/example-jsonld-nofhir/SA301.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/SA301.jsonld
@@ -1,55 +1,55 @@
 {
-  "@context":"http://clingen.org/models/SimpleAllele.jsonld",
+  "@context": "http://clingen.org/models/SimpleAllele.jsonld",
   "@id": "http://clingendb.clingen.org/SimpleAllele/SA301",
   "@type": "SimpleAllele",
-  "xref": 
+  "xref":
   [
     "http://clingen/alleleregistry/SA301"
   ],
 
 
-  "canonicalAllele":"../../CanonicalAllele/CA401",
+  "canonicalAllele": "../../CanonicalAllele/CA401",
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "@type":"PrimaryNucleotideChangeType",
-    "@id":""http://www.sequenceontology.org/SO:1000002",
+    "@type": "PrimaryNucleotideChangeType",
+    "@id": "http://www.sequenceontology.org/SO:1000002",
     "display": "substitution",
     "primary": "true"
-  }
-  "alleleName": 
+  },
+  "alleleName":
   [
     {
-      "@type":"AlleleName",
+      "@type": "AlleleName",
       "nameType": "hgvs-cdna",
       "name": "NM_001014794.2:c.448+14A>G",
       "preferred": "true"
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "@type":"ReferenceCoordinate",
+    "@type": "ReferenceCoordinate",
     "referenceSequence": "../../ReferenceSequence/RS201",
     "start": "608",
     "end": "608",
     "refAllele": "A",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-        "@type":"PrimaryTranscriptRegionType",
-        "@id":"http://www.sequenceontology.org/SO:0000188",
-        "display":"intron"
-    }
+        "@type": "PrimaryTranscriptRegionType",
+        "@id": "http://www.sequenceontology.org/SO:0000188",
+        "display": "intron"
+    },
 
     "intronOffsetStart": "13",
     "intronOffsetEnd": "14",
     "intronOffsetDirection": "+",
-    "intronOffsetGenomicCoordinate": 
+    "intronOffsetGenomicCoordinate":
     {
-        "@type":"IntronOffsetGenomicCoordinate",
-        "referenceSequence":"../../ReferenceSequence/RS202",
+        "@type": "IntronOffsetGenomicCoordinate",
+        "referenceSequence": "../../ReferenceSequence/RS202",
         "start": "6630033",
         "end": "6630034",
         "refAllele": "A"

--- a/source/main/resources/example-jsonld-nofhir/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.jsonld
@@ -1,8 +1,8 @@
 {
-  "@context":"http://clingen.org/models/SimpleAllele.jsonld",
+  "@context": "http://clingen.org/models/SimpleAllele.jsonld",
   "@id": "http://clingendb.clingen.org/SimpleAllele/SA302",
-  "@type":"SimpleAllele",
-  "xref": 
+  "@type": "SimpleAllele",
+  "xref":
   [
     "http://clingen/alleleregistry/SA302"
   ],
@@ -11,35 +11,34 @@
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "@type":"PrimaryNucleotideChangeType",
+    "@type": "PrimaryNucleotideChangeType",
     "@id": "http://www.sequenceontology.org/SO:1000002",
     "display": "substitution",
     "primary": "true"
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
-      "@type":"AlleleName",
+      "@type": "AlleleName",
       "nameType": "hgvs-cdna",
       "name": "NM_001014794.2:c.448+13A>G",
       "preferred": "true"
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "@type":"ReferenceCoordinate",
-    "referenceSequence": :"../../ReferenceSequence/RS201",
+    "@type": "ReferenceCoordinate",
+    "referenceSequence": "../../ReferenceSequence/RS201",
     "start": "608",
     "end": "608",
     "refAllele": "A",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "@type":"PrimaryTranscriptRegionType",
-      "coding": 
+      "@type": "PrimaryTranscriptRegionType",
       "@id": "http://www.sequenceontology.org/SO:0000188",
       "display": "intron",
     },
@@ -47,10 +46,10 @@
     "intronOffsetStart": "12",
     "intronOffsetEnd": "13",
     "intronOffsetDirection": "+",
-    "intronOffsetGenomicCoordinate": 
+    "intronOffsetGenomicCoordinate":
     {
-      "@type":"IntronOffsetGenomicCoordinate",
-      "referenceSequence":"../../ReferenceSequence/RS203",
+      "@type": "IntronOffsetGenomicCoordinate",
+      "referenceSequence": "../../ReferenceSequence/RS203",
       "start": "6608802",
       "end": "6608803",
       "refAllele": "A"

--- a/source/main/resources/example-jsonld/CA401-NM_001014794.2-c.448+13A>G.jsonld
+++ b/source/main/resources/example-jsonld/CA401-NM_001014794.2-c.448+13A>G.jsonld
@@ -1,51 +1,51 @@
 {
-  "@context":"http://clingen.org/models/CanonicalAllele.jsonld",
+  "@context": "http://clingen.org/models/CanonicalAllele.jsonld",
   "@id": "http://clingendb.clingen.org/CanonicalAllele/CA401",
-  "@type":"CanonicalAllele",
+  "@type": "CanonicalAllele",
   "id": "CA401",
   "version": "1",
   "active": "true",
   "canonicalAlleleType": "nucleotide",
   "complexity": "simple",
-  "relatedSimpleAllele": 
+  "relatedSimpleAllele":
   [
     {
-      "@type":"RelatedSimpleAllele",
-      "simpleAllele": 
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele":
       {
-        "@type":"Reference",
+        "@type": "Reference",
         "reference": "../../SimpleAllele/SA302",
-        "display": "NM_001014794.2(ILK):c.448+13A>G "
+        "display": "NM_001014794.2(ILK):c.448+13A>G"
       },
 
       "preferred": "true"
     },
 
     {
-      "@type":"RelatedSimpleAllele",
-      "simpleAllele": 
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele":
       {
-        "@type":"Reference",
+        "@type": "Reference",
         "reference": "../../SimpleAllele/SA301",
-        "display": "NM_001014794.2(ILK):c.448+14A>G "
+        "display": "NM_001014794.2(ILK):c.448+14A>G"
       }
     },
 
     {
-      "@type":"RelatedSimpleAllele",
-      "simpleAllele": 
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele":
       {
-        "@type":"Reference",
+        "@type": "Reference",
         "reference": "../../SimpleAllele/SA303",
         "display": "NC_000011.9:g.6630034A>G (GRCh37)"
       }
     },
 
     {
-      "@type":"RelatedSimpleAllele",
-      "simpleAllele": 
+      "@type": "RelatedSimpleAllele",
+      "simpleAllele":
       {
-        "@type":"Reference",
+        "@type": "Reference",
         "reference": "../../SimpleAllele/SA304",
         "display": "NC_000011.10:g.6608803A>G (GRCh38)"
       }

--- a/source/main/resources/example-jsonld/G101-ILK.jsonld
+++ b/source/main/resources/example-jsonld/G101-ILK.jsonld
@@ -1,22 +1,22 @@
 {
-    "@context":"http://clingen.org/models/Gene.jsonld"
-    "@id":"http://clingendb.clingen.org/Gene/G101",
-    "@type":"Gene",
+    "@context": "http://clingen.org/models/Gene.jsonld",
+    "@id": "http://clingendb.clingen.org/Gene/G101",
+    "@type": "Gene",
     "id": "G101",
     "symbol": "ILK",
     "name": "integrin-linked kinase",
     "identifier":
     [
         {
-            "@type":"Identifier"
-            "use":"usual",
-            "system":"urn:oid:2.16.840.1.113883.6.281",
+            "@type": "Identifier",
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.6.281",
             "value": "HGNC:6040"
         },
         {
-            "@type":"Identifier"
-            "use":"secondary",
-            "system":"http://www.ncbi.nlm.nih.gov/gene",
+            "@type": "Identifier",
+            "use": "secondary",
+            "system": "http://www.ncbi.nlm.nih.gov/gene",
             "value": "3661"
         }
     ]

--- a/source/main/resources/example-jsonld/G102-BRCA1.jsonld
+++ b/source/main/resources/example-jsonld/G102-BRCA1.jsonld
@@ -1,19 +1,19 @@
 {
-  "@context":"http://clingen.org/models/Gene.jsonld",
+  "@context": "http://clingen.org/models/Gene.jsonld",
   "@id": "http://clingendb.clingen.org/Gene/G102",
   "@type": "clingen:Gene",
-  "id": "G102", 
-  "identifier": 
+  "id": "G102",
+  "identifier":
   [
     {
-      "@type":"Identifier",
+      "@type": "Identifier",
       "use": "usual",
       "system": "http://www.genenames.org/",
       "value": "HGNC:1100"
     },
 
     {
-      "@type":"Identifier",
+      "@type": "Identifier",
       "use": "secondary",
       "system": "http://www.ncbi.nlm.nih.gov/gene",
       "value": "672"
@@ -22,7 +22,7 @@
 
   "symbol": "BRCA1",
   "name": "breast cancer 1, early onset",
-  "aliasSymbol": 
+  "aliasSymbol":
   [
     "IRIS",
     "PSCP",

--- a/source/main/resources/example-jsonld/RS201-NM_001014794.2-ILK.jsonld
+++ b/source/main/resources/example-jsonld/RS201-NM_001014794.2-ILK.jsonld
@@ -1,12 +1,12 @@
 {
-  "@context":"http://clingen.org/models/ReferenceSequence.jsonld",
+  "@context": "http://clingen.org/models/ReferenceSequence.jsonld",
   "@id": "http://clingendb.clingen.org/ReferenceSequence/RS201",
   "@type": "ReferenceSequence",
   "id": "RS201",
-  "identifier": 
+  "identifier":
   [
     {
-      "@type":"Identifier",
+      "@type": "Identifier",
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
       "value": "NM_001014794.2"
     }
@@ -15,10 +15,9 @@
   "referenceSequenceType": "transcript",
   "cdsStart": "162",
   "cdsEnd": "1520",
-  "gene": 
+  "gene":
   {
-      "@type":"Reference",
-      "reference":"../../Gene/G101"
+      "@type": "Reference",
+      "reference": "../../Gene/G101"
   }
-        
 }

--- a/source/main/resources/example-jsonld/RS202-NC_000011.9-b37.jsonld
+++ b/source/main/resources/example-jsonld/RS202-NC_000011.9-b37.jsonld
@@ -1,12 +1,12 @@
 {
-  "@context":"http://clingen.org/models/ReferenceSequence.jsonld",
+  "@context": "http://clingen.org/models/ReferenceSequence.jsonld",
   "@id": "http://clingendb.clingen.org/ReferenceSequence/RS202",
-  "@type:":"ReferenceSequence",
-  "id":"RS202",
-  "identifier": 
-  [ 
+  "@type:": "ReferenceSequence",
+  "id": "RS202",
+  "identifier":
+  [
     {
-      "@type":"Identifier",
+      "@type": "Identifier",
       "system": "http://www.ncbi.nlm.nih.gov/nuccore",
       "value": "NC_000011.9"
     }
@@ -14,13 +14,13 @@
 
   "referenceSequenceType": "chromosome",
   "chromosome": "11",
-  "referenceGenome": 
+  "referenceGenome":
   {
-    "@type":"ReferenceGenome",
-    "coding": 
+    "@type": "ReferenceGenome",
+    "coding":
     [
       {
-        "@type":"Code"
+        "@type": "Code",
         "system": "http://www.ncbi.nlm.nih.gov/assembly/",
         "code": "2758"
       }

--- a/source/main/resources/example-jsonld/SA301.jsonld
+++ b/source/main/resources/example-jsonld/SA301.jsonld
@@ -1,90 +1,90 @@
 {
-  "@context":"http://clingen.org/models/SimpleAllele.jsonld",
+  "@context": "http://clingen.org/models/SimpleAllele.jsonld",
   "@id": "http://clingendb.clingen.org/SimpleAllele/SA301",
   "@type": "SimpleAllele",
   "id": "SA301",
-  "identifier": 
+  "identifier":
   [
     {
-      "@type":"Identifier"
+      "@type": "Identifier",
       "system": "http://clingen/alleleregistry",
       "value": "SA301"
     }
   ],
 
 
-  "canonicalAllele": 
+  "canonicalAllele":
   {
-    "@type":"Reference",
-    "reference":"../../CanonicalAllele/CA401"
+    "@type": "Reference",
+    "reference": "../../CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "@type":"PrimaryNucleotideChangeType",
+    "@type": "PrimaryNucleotideChangeType",
     "coding":
     [
-        {
-            "@type":"Code",
-            "system":""http://www.sequenceontology.org/",
-            "code": "SO:1000002",
-            "display": "substitution",
-            "primary": "true"
-        }
+      {
+        "@type": "Code",
+        "system": "http://www.sequenceontology.org/",
+        "code": "SO:1000002",
+        "display": "substitution",
+        "primary": "true"
+      }
     ]
-  }
-  "alleleName": 
+  },
+  "alleleName":
   [
     {
-      "@type":"AlleleName",
+      "@type": "AlleleName",
       "nametype": "hgvs-cdna",
       "name": "NM_001014794.2:c.448+14A>G",
       "preferred": "true"
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "@type":"ReferenceCoordinate",
-    "referenceSequence": 
+    "@type": "ReferenceCoordinate",
+    "referenceSequence":
     {
-        "@type":"Reference",
-        "reference": "../../ReferenceSequence/RS201",
-    }
+      "@type": "Reference",
+      "reference": "../../ReferenceSequence/RS201"
+    },
     "start": "608",
     "end": "608",
     "refAllele": "A",
 
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-        "@type":"PrimaryTranscriptRegionType",
-        "coding":
-        [
-            {
-                "@type":"Code",
-                "system":"http://www.sequenceontology.org/",
-                "code":"SO:0000188",
-                "display":"intron"
-            }
-        ]
-    }
+      "@type": "PrimaryTranscriptRegionType",
+      "coding":
+      [
+        {
+          "@type": "Code",
+          "system": "http://www.sequenceontology.org/",
+          "code": "SO:0000188",
+          "display": "intron"
+        }
+      ]
+    },
 
     "intronOffsetStart": "13",
     "intronOffsetEnd": "14",
     "intronOffsetDirection": "+",
-    "intronOffsetGenomicCoordinate": 
+    "intronOffsetGenomicCoordinate":
     {
-        "@type":"IntronOffsetGenomicCoordinate",
-        "referenceSequence": 
-        {
-            "@type":"Reference",
-            "reference","../../ReferenceSequence/RS202"
-        }
-        "start": "6630033",
-        "end": "6630034",
-        "refAllele": "A"
+      "@type": "IntronOffsetGenomicCoordinate",
+      "referenceSequence":
+      {
+        "@type": "Reference",
+        "reference": "../../ReferenceSequence/RS202"
+      },
+      "start": "6630033",
+      "end": "6630034",
+      "refAllele": "A"
     }
   }
 }

--- a/source/main/resources/example-jsonld/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.jsonld
+++ b/source/main/resources/example-jsonld/SA302-NM_001014794.2-ILK-c.448+13A>G-b38.jsonld
@@ -1,9 +1,9 @@
 {
-  "@context":"http://clingen.org/models/SimpleAllele.jsonld",
+  "@context": "http://clingen.org/models/SimpleAllele.jsonld",
   "@id": "http://clingendb.clingen.org/SimpleAllele/SA302",
-  "@type":"SimpleAllele",
+  "@type": "SimpleAllele",
   "id": "SA302",
-  "identifier": 
+  "identifier":
   [
     {
       "@type": "Identifier",
@@ -12,21 +12,21 @@
     }
   ],
 
-  "canonicalAllele": 
+  "canonicalAllele":
   {
-    "@type":"Reference",
-    "reference":"../../CanonicalAllele/CA401"
+    "@type": "Reference",
+    "reference": "../../CanonicalAllele/CA401"
   },
 
   "simpleAlleleType": "transcript",
   "allele": "G",
-  "primaryNucleotideChangeType": 
+  "primaryNucleotideChangeType":
   {
-    "@type":"PrimaryNucleotideChangeType",
-    "coding": 
+    "@type": "PrimaryNucleotideChangeType",
+    "coding":
     [
       {
-        "@type":"Code",
+        "@type": "Code",
         "system": "http://www.sequenceontology.org/",
         "code": "SO:1000002",
         "display": "substitution",
@@ -35,35 +35,35 @@
     ]
   },
 
-  "alleleName": 
+  "alleleName":
   [
     {
-      "@type":"AlleleName",
+      "@type": "AlleleName",
       "nametype": "hgvs-cdna",
       "name": "NM_001014794.2:c.448+13A>G",
       "preferred": "true"
     }
   ],
 
-  "referenceCoordinate": 
+  "referenceCoordinate":
   {
-    "@type":"ReferenceCoordinate",
-    "referenceSequence": 
+    "@type": "ReferenceCoordinate",
+    "referenceSequence":
     {
-        "@type":"Reference",
-        "reference":"../../ReferenceSequence/RS201",
-        "display":"NM_001014794.2"
-    }
+      "@type": "Reference",
+      "reference": "../../ReferenceSequence/RS201",
+      "display": "NM_001014794.2"
+    },
     "start": "608",
     "end": "608",
     "refAllele": "A",
-    "primaryTranscriptRegionType": 
+    "primaryTranscriptRegionType":
     {
-      "@type":"PrimaryTranscriptRegionType",
-      "coding": 
+      "@type": "PrimaryTranscriptRegionType",
+      "coding":
       [
         {
-          "@type":"Code",
+          "@type": "Code",
           "system": "http://www.sequenceontology.org/",
           "code": "SO:0000188",
           "display": "intron"
@@ -74,15 +74,15 @@
     "intronOffsetStart": "12",
     "intronOffsetEnd": "13",
     "intronOffsetDirection": "+",
-    "intronOffsetGenomicCoordinate": 
+    "intronOffsetGenomicCoordinate":
     {
-      "@type":"IntronOffsetGenomicCoordinate",
-      "referenceSequence": 
+      "@type": "IntronOffsetGenomicCoordinate",
+      "referenceSequence":
       {
-        "@type":"Reference",
-        "reference":"../../ReferenceSequence/RS203",
-        "display":"NC_000011.10"
-      }
+        "@type": "Reference",
+        "reference": "../../ReferenceSequence/RS203",
+        "display": "NC_000011.10"
+      },
       "start": "6608802",
       "end": "6608803",
       "refAllele": "A"


### PR DESCRIPTION
Similar to PR #121, fixing the syntax in the examples and imposing a uniform coding style is necessary for the examples to be understandable.
