### PR TITLE
Add JSON-LD context files for Provenance

### DIFF
--- a/source/main/resources/example-jsonld-nofhir/Provenance.jsonld
+++ b/source/main/resources/example-jsonld-nofhir/Provenance.jsonld
@@ -1,0 +1,15 @@
+{
+    "@context":
+    {
+        "fhir":"http://hl7.org/fhir/resources/",
+        "clingen":"http://clingen.org/model/allele/",
+        "xsd":"http://www.w3.org/2001/XMLSchema#",
+
+        "target":"@set",
+        "period":"fhir:Period",
+        "recorded":"xsd:dateTime",
+        "reason":"fhir:CodeableConcept",
+        "entity":"@set",
+        "role":"fhir:Code"
+    }
+}

--- a/source/main/resources/example-jsonld/Provenance.jsonld
+++ b/source/main/resources/example-jsonld/Provenance.jsonld
@@ -1,0 +1,15 @@
+{
+    "@context":
+    {
+        "fhir":"http://hl7.org/fhir/resources/",
+        "clingen":"http://clingen.org/model/allele/",
+        "xsd":"http://www.w3.org/2001/XMLSchema#",
+
+        "target":"@set",
+        "period":"fhir:Period",
+        "recorded":"xsd:dateTime",
+        "reason":"fhir:CodeableConcept",
+        "entity":"@set",
+        "role":"fhir:Code"
+    }
+}


### PR DESCRIPTION
I used the same file contents for both example-jsonld and example-jsonld-nofhir because I couldn't tell from the other examples what the difference was supposed to be.
